### PR TITLE
Improve API documentation

### DIFF
--- a/docs/read.qmd
+++ b/docs/read.qmd
@@ -5,7 +5,6 @@ title: "Read"
 This page shows how to read SEGY data using **pysegy**.
 
 ```{python}
-#| eval: false
 import pysegy as seg
 
 # path to a SEGY file
@@ -18,6 +17,7 @@ block = seg.segy_read(path)
 print(block.fileheader.bfh.ns)
 ```
 
-Use :func:`pysegy.segy_read` to read an entire file in one call. The
-returned :class:`pysegy.SeisBlock` contains the file header, trace headers
-and data array.
+Use [pysegy.segy_read](reference/pysegy.qmd#segy_read) to read an entire
+file in one call. The returned
+[pysegy.SeisBlock](reference/pysegy.qmd#SeisBlock) contains the file
+header, trace headers and data array.

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -5,3 +5,10 @@
 | | |
 | --- | --- |
 | [pysegy](pysegy.qmd#pysegy) | Minimal Python port of SegyIO.jl. |
+| [segy_scan](pysegy.qmd#segy_scan) | Scan one or more SEGY files |
+| [segy_read](pysegy.qmd#segy_read) | Read an entire SEGY file |
+| [segy_write](pysegy.qmd#segy_write) | Write a SEGY file |
+| [get_header](pysegy.qmd#get_header) | Extract header values |
+| [ShotRecord](pysegy.qmd#ShotRecord) | Metadata for a single shot |
+| [SegyScan](pysegy.qmd#SegyScan) | Collection of ShotRecord objects |
+| [SeisBlock](pysegy.qmd#SeisBlock) | In-memory data block |

--- a/docs/reference/pysegy.qmd
+++ b/docs/reference/pysegy.qmd
@@ -1,5 +1,43 @@
-# pysegy { #pysegy }
+# pysegy {#pysegy}
 
-``
+API reference for the main helpers and data structures.
 
-Minimal Python port of SegyIO.jl.
+## segy_scan {#segy_scan}
+Scan one or more SEGY files and return a [SegyScan](#SegyScan).
+
+```python
+pysegy.segy_scan(path, file_key=None, keys=None, chunk=1024,
+                 depth_key="SourceDepth", rec_depth_key="GroupWaterDepth",
+                 threads=None, fs=None)
+```
+
+## segy_read {#segy_read}
+Read an entire SEGY file into a [SeisBlock](#SeisBlock).
+
+```python
+pysegy.segy_read(path, keys=None, workers=5, fs=None)
+```
+
+## segy_write {#segy_write}
+Write a [SeisBlock](#SeisBlock) to disk.
+
+```python
+pysegy.segy_write(path, block, fs=None)
+```
+
+## get_header {#get_header}
+Extract header values from a block or list of headers.
+
+```python
+pysegy.get_header(src, name, scale=True)
+```
+
+## ShotRecord {#ShotRecord}
+Metadata describing a single shot in a survey.
+
+## SegyScan {#SegyScan}
+Collection of [ShotRecord](#ShotRecord) objects produced by
+[segy_scan](#segy_scan).
+
+## SeisBlock {#SeisBlock}
+In-memory representation of traces read from a SEGY file.

--- a/docs/scan.qmd
+++ b/docs/scan.qmd
@@ -6,7 +6,6 @@ Scanning allows inspecting large surveys without loading everything in
 memory.
 
 ```{python}
-#| eval: false
 import pysegy as seg
 
 # scan all matching files in the directory
@@ -16,5 +15,7 @@ print(len(scan.shots))  # number of shot records
 print(scan.counts[0])   # traces in the first shot
 ```
 
-The :func:`pysegy.segy_scan` function summarises multiple files and
-returns a :class:`pysegy.SegyScan` that can lazily read data for each shot.
+The [pysegy.segy_scan](reference/pysegy.qmd#segy_scan) function
+summarises multiple files and returns a
+[pysegy.SegyScan](reference/pysegy.qmd#SegyScan) that can lazily read data
+for each shot.

--- a/docs/write.qmd
+++ b/docs/write.qmd
@@ -5,7 +5,6 @@ title: "Write"
 Writing SEGY files mirrors the reading workflow.
 
 ```{python}
-#| eval: false
 import numpy as np
 import pysegy as seg
 
@@ -23,5 +22,6 @@ block = seg.SeisBlock(fh, [hdr], data)
 seg.segy_write("out.segy", block)
 ```
 
-The :func:`pysegy.segy_write` helper takes a :class:`pysegy.SeisBlock` and
-writes a complete SEGY file to disk.
+The [pysegy.segy_write](reference/pysegy.qmd#segy_write) helper takes a
+[pysegy.SeisBlock](reference/pysegy.qmd#SeisBlock) and writes a complete
+SEGY file to disk.


### PR DESCRIPTION
## Summary
- document `segy_scan`, `segy_read`, `segy_write`, and `get_header`
- describe primary data structures
- show output of examples and cross-link to API reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfd0ba2c8832f9d72f277938c2e22