### PR TITLE
Add badges and PyPI deploy workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,26 @@
+name: Deploy to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Build package
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # pysegy
 
+[![CI](https://github.com/mloubout/pysegy/actions/workflows/main.yml/badge.svg)](https://github.com/mloubout/pysegy/actions/workflows/main.yml)
+[![Docs](https://github.com/mloubout/pysegy/actions/workflows/docs.yml/badge.svg)](https://mloubout.github.io/pysegy)
+[![codecov](https://codecov.io/gh/mloubout/pysegy/branch/master/graph/badge.svg)](https://codecov.io/gh/mloubout/pysegy)
+
 `pysegy` is a minimal Python library for reading and writing SEGY Rev 1 files. The package focuses on simplicity and provides helpers to parse headers and traces from local files.
 
 ## Installation


### PR DESCRIPTION
## Summary
- show CI, docs and codecov badges in README
- add GitHub Actions workflow to deploy releases to PyPI

## Testing
- `pip install -e .[dev]`
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_685c01de1b04832fb1d1b78b65ff37d4