### PR TITLE
Add receiver gather scanning

### DIFF
--- a/docs/scan.qmd
+++ b/docs/scan.qmd
@@ -19,4 +19,5 @@ print(scan.counts[0])   # traces in the first shot
 The [pysegy.segy_scan](reference/segy_scan.html#pysegy.segy_scan) function
 summarises multiple files and returns a
 [pysegy.SegyScan](reference/SegyScan.html#pysegy.SegyScan) that can lazily read data
-for each shot.
+for each shot. Use ``by_receiver=True`` to group traces by receiver coordinates
+instead of source coordinates.

--- a/pysegy/tests/test_python.py
+++ b/pysegy/tests/test_python.py
@@ -226,6 +226,46 @@ def test_scan_unsorted_traces(tmp_path):
     assert scan.summary(0)["GroupX"] == (1, 3)
 
 
+def test_scan_by_receiver_gather(tmp_path):
+    """Group traces by receiver location instead of source."""
+    fh = FileHeader()
+    fh.bfh.ns = 1
+    fh.bfh.DataSampleFormat = 5
+
+    h1 = BinaryTraceHeader()
+    h1.ns = 1
+    h1.SourceX = 1
+    h1.SourceY = 1
+    h1.GroupX = 5
+    h1.GroupY = 0
+
+    h2 = BinaryTraceHeader()
+    h2.ns = 1
+    h2.SourceX = 2
+    h2.SourceY = 2
+    h2.GroupX = 5
+    h2.GroupY = 0
+
+    h3 = BinaryTraceHeader()
+    h3.ns = 1
+    h3.SourceX = 3
+    h3.SourceY = 3
+    h3.GroupX = 10
+    h3.GroupY = 0
+
+    headers = [h1, h2, h3]
+    data = np.zeros((1, 3), dtype=np.float32)
+    block = SeisBlock(fh, headers, data)
+    tmp = tmp_path / "rec_gather.segy"
+    with open(tmp, "wb") as f:
+        seg.write.write_block(f, block)
+
+    scan = seg.segy_scan(str(tmp), by_receiver=True)
+    assert len(scan.shots) == 2
+    assert scan.counts == [2, 1]
+    assert scan.shots[0] == (5.0, 0.0, 0.0)
+
+
 def test_save_and_load_scan(tmp_path):
     scan = seg.segy_scan(DATAFILE)
     dest = tmp_path / "scan.pkl"


### PR DESCRIPTION
## Summary
- allow scanning SEGY files grouped by receiver location
- document the `by_receiver` option in the docs
- test receiver gather scanning
- show receiver gather example in bp_scan tutorial

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68601162a3e8832f8680bdb4e3a785dd