### PR TITLE
Refine helpers and standardise docstrings

### DIFF
--- a/pysegy/__init__.py
+++ b/pysegy/__init__.py
@@ -1,4 +1,6 @@
-"""Minimal Python port of SegyIO.jl."""
+"""
+Minimal Python port of SegyIO.jl.
+"""
 from importlib.metadata import version, PackageNotFoundError
 
 from .types import (

--- a/pysegy/plotting.py
+++ b/pysegy/plotting.py
@@ -1,4 +1,5 @@
-"""Utility helpers for quick visualisation of seismic data.
+"""
+Utility helpers for quick visualisation of seismic data.
 
 The helpers mirror a subset of the `SlimPlotting.jl` API and can work
 directly with :class:`~pysegy.SeisBlock` or :class:`~pysegy.ShotRecord`

--- a/pysegy/read.py
+++ b/pysegy/read.py
@@ -52,7 +52,7 @@ def read_fileheader(
         offset = FH_BYTE2SAMPLE[k]
         # All file header fields are integers of 2 or 4 bytes
         size = 4 if k in ("Job", "Line", "Reel") else 2
-        val_bytes = text_header[offset : offset + size]
+        val_bytes = text_header[offset:offset + size]
         val = unpack_int(val_bytes, size, bigendian)
         setattr(bfh, k, val)
     bfh.keys_loaded = list(keys)
@@ -87,7 +87,7 @@ def read_traceheader(
     th = BinaryTraceHeader()
     for k in keys:
         offset, size = TH_BYTE2SAMPLE[k]
-        val = unpack_int(hdr_bytes[offset : offset + size], size, bigendian)
+        val = unpack_int(hdr_bytes[offset:offset + size], size, bigendian)
         setattr(th, k, val)
     th.keys_loaded = list(keys)
     return th
@@ -141,14 +141,14 @@ def read_traces(
 
     def parse_one(idx: int):
         offset = idx * trace_size
-        hdr_buf = raw[offset : offset + 240]
+        hdr_buf = raw[offset:offset + 240]
         hdr = BinaryTraceHeader()
         for k, off_k, size_k in hdr_parsers:
-            val = unpack_int(hdr_buf[off_k : off_k + size_k], size_k, bigendian)
+            val = unpack_int(hdr_buf[off_k:off_k + size_k], size_k, bigendian)
             setattr(hdr, k, val)
         hdr.keys_loaded = key_list
 
-        data_buf = raw[offset + 240 : offset + trace_size]
+        data_buf = raw[offset + 240:offset + trace_size]
         samples = read_samples(data_buf, ns, datatype, bigendian)
         return idx, hdr, samples
 

--- a/pysegy/tests/test_python.py
+++ b/pysegy/tests/test_python.py
@@ -43,12 +43,16 @@ def test_write_roundtrip(tmp_path):
 
 
 def test_ibm_conversion():
-    """Ensure IBM -> IEEE conversion works for known constant."""
+    """
+    Ensure IBM -> IEEE conversion works for known constant.
+    """
     assert ibm_to_ieee(b"\x41\x10\x00\x00") == 1.0
 
 
 def test_fileheader_io():
-    """Round-trip a file header using in-memory bytes."""
+    """
+    Round-trip a file header using in-memory bytes.
+    """
     fh = FileHeader()
     fh.bfh.Job = 99
     fh.bfh.Line = 123
@@ -62,7 +66,9 @@ def test_fileheader_io():
 
 
 def test_write_read_block_bytesio():
-    """Write and read a simple block using BytesIO."""
+    """
+    Write and read a simple block using BytesIO.
+    """
     fh = FileHeader()
     fh.bfh.ns = 2
     fh.bfh.DataSampleFormat = 5
@@ -107,7 +113,9 @@ BP_URL = (
 
 
 def test_bp_model_headers():
-    """Download a portion of the BP model data and verify header values."""
+    """
+    Download a portion of the BP model data and verify header values.
+    """
     response = urllib.request.urlopen(BP_URL)
     with gzip.GzipFile(fileobj=response) as gz:
         data = gz.read(40000)
@@ -189,7 +197,9 @@ def test_scan_with_filesystem():
 
 
 def test_scan_unsorted_traces(tmp_path):
-    """Ensure scanning handles files with interleaved shots."""
+    """
+    Ensure scanning handles files with interleaved shots.
+    """
     fh = FileHeader()
     fh.bfh.ns = 1
     fh.bfh.DataSampleFormat = 5
@@ -227,7 +237,9 @@ def test_scan_unsorted_traces(tmp_path):
 
 
 def test_scan_by_receiver_gather(tmp_path):
-    """Group traces by receiver location instead of source."""
+    """
+    Group traces by receiver location instead of source.
+    """
     fh = FileHeader()
     fh.bfh.ns = 1
     fh.bfh.DataSampleFormat = 5

--- a/pysegy/types.py
+++ b/pysegy/types.py
@@ -195,13 +195,17 @@ class BinaryFileHeader:
     keys_loaded: List[str] = field(default_factory=lambda: list(FH_FIELDS))
 
     def __getattr__(self, name):
-        """Return the value for ``name`` from ``values``."""
+        """
+        Return the value for ``name`` from ``values``.
+        """
         if name in self.values:
             return self.values[name]
         raise AttributeError(name)
 
     def __setattr__(self, name, value):
-        """Set ``name`` in ``values`` when it is a header field."""
+        """
+        Set ``name`` in ``values`` when it is a header field.
+        """
         if name in {"values", "keys_loaded"} or name not in FH_FIELDS:
             super().__setattr__(name, value)
         else:
@@ -210,7 +214,9 @@ class BinaryFileHeader:
                 self.keys_loaded.append(name)
 
     def __str__(self):
-        """Return a multi-line representation of loaded fields."""
+        """
+        Return a multi-line representation of loaded fields.
+        """
         lines = ["BinaryFileHeader:"]
         fields = self.keys_loaded or FH_FIELDS
         for k in fields:
@@ -237,7 +243,9 @@ class FileHeader:
     bfh: BinaryFileHeader = field(default_factory=BinaryFileHeader)
 
     def __str__(self) -> str:
-        """Return a readable representation of the header."""
+        """
+        Return a readable representation of the header.
+        """
         return str(self.bfh)
 
     __repr__ = __str__
@@ -255,13 +263,17 @@ class BinaryTraceHeader:
     keys_loaded: List[str] = field(default_factory=list)
 
     def __getattr__(self, name):
-        """Return the header value ``name``."""
+        """
+        Return the header value ``name``.
+        """
         if name in self.values:
             return self.values[name]
         raise AttributeError(name)
 
     def __setattr__(self, name, value):
-        """Assign ``value`` to ``name`` when valid."""
+        """
+        Assign ``value`` to ``name`` when valid.
+        """
         if name in {"values", "keys_loaded"} or name not in TH_FIELDS:
             super().__setattr__(name, value)
         else:
@@ -280,7 +292,9 @@ class BinaryTraceHeader:
         super().__setattr__("keys_loaded", state["keys_loaded"])
 
     def __str__(self):
-        """Return a multi-line representation of loaded fields."""
+        """
+        Return a multi-line representation of loaded fields.
+        """
         lines = ["BinaryTraceHeader:"]
         fields = self.keys_loaded or TH_FIELDS
         for k in fields:

--- a/pysegy/utils.py
+++ b/pysegy/utils.py
@@ -1,6 +1,15 @@
-from typing import Iterable, List, Union
+"""
+Utility helpers shared across the :mod:`pysegy` package.
+"""
+
+from typing import BinaryIO, Iterable, List, Union
+from contextlib import contextmanager
+import struct
+from functools import lru_cache
+import numpy as np
 
 from .types import BinaryTraceHeader, SeisBlock
+from .ibm import ibm_to_ieee_array, ieee_to_ibm
 
 _RECSRC_FIELDS = {
     "SourceX",
@@ -30,13 +39,78 @@ def _check_scale(name: str) -> tuple[bool, str]:
     return False, ""
 
 
+@lru_cache(maxsize=None)
+def struct_fmt(size: int, bigendian: bool) -> str:
+    """
+    Return ``struct`` format for ``size`` byte integer.
+    """
+    return (">" if bigendian else "<") + ("i" if size == 4 else "h")
+
+
+@lru_cache(maxsize=None)
+def struct_obj(size: int, bigendian: bool) -> struct.Struct:
+    """
+    Return cached :class:`struct.Struct` instance for the given integer size.
+    """
+    return struct.Struct(struct_fmt(size, bigendian))
+
+
+def unpack_int(buf: bytes, size: int, bigendian: bool) -> int:
+    """
+    Decode integer from ``buf`` with ``size`` bytes.
+    """
+    return struct_obj(size, bigendian).unpack(buf)[0]
+
+
+def pack_int(value: int, size: int, bigendian: bool) -> bytes:
+    """
+    Encode ``value`` to bytes according to ``size`` and endianness.
+    """
+    return struct_obj(size, bigendian).pack(value)
+
+
+def read_samples(buf: bytes, ns: int, datatype: int, bigendian: bool) -> np.ndarray:
+    """
+    Return ``ns`` samples from ``buf`` given the SEGY data type.
+    """
+    if datatype == 1:
+        return ibm_to_ieee_array(buf, ns, bigendian)
+    dtype = (">" if bigendian else "<") + "f4"
+    return np.frombuffer(buf, dtype=dtype, count=ns)
+
+
+def write_samples(
+    f: BinaryIO, trace: Iterable[float], datatype: int, bigendian: bool
+) -> None:
+    """
+    Write ``trace`` values to ``f`` according to the SEGY format.
+    """
+    if datatype == 1:
+        f.write(b"".join(ieee_to_ibm(float(x)) for x in trace))
+    else:
+        fmt = (">" if bigendian else "<") + f"{len(trace)}f"
+        f.write(struct.pack(fmt, *trace))
+
+
+@contextmanager
+def open_file(path: str, mode: str = "rb", fs=None):
+    """
+    Context manager opening ``path`` using ``fs`` when provided.
+    """
+    opener = fs.open if fs is not None else open
+    with opener(path, mode) as fh:
+        yield fh
+
+
 def get_header(
     src: Union[SeisBlock, Iterable[BinaryTraceHeader]],
     name: str,
     *,
     scale: bool = True,
 ) -> List[float]:
-    """Return values for ``name`` from ``src`` optionally applying scaling."""
+    """
+    Return values for ``name`` from ``src`` optionally applying scaling.
+    """
     if isinstance(src, SeisBlock):
         headers = src.traceheaders
     else:
@@ -59,4 +133,12 @@ def get_header(
     return vals
 
 
-__all__ = ["get_header"]
+__all__ = [
+    "get_header",
+    "open_file",
+    "read_samples",
+    "write_samples",
+    "struct_fmt",
+    "pack_int",
+    "unpack_int",
+]

--- a/pysegy/write.py
+++ b/pysegy/write.py
@@ -13,7 +13,6 @@ from .types import (
     FH_BYTE2SAMPLE,
     TH_BYTE2SAMPLE,
 )
-from .ibm import ieee_to_ibm
 
 
 def write_fileheader(

--- a/pysegy/write.py
+++ b/pysegy/write.py
@@ -4,6 +4,8 @@ Writing utilities for the minimal Python SEGY implementation.
 
 import struct
 from typing import BinaryIO
+
+from .utils import pack_int, struct_fmt, write_samples, open_file
 from .types import (
     SeisBlock,
     FileHeader,
@@ -38,10 +40,7 @@ def write_fileheader(
     for key in FH_BYTE2SAMPLE:
         val = getattr(bfh, key)
         size = 4 if key in ("Job", "Line", "Reel") else 2
-        fmt = ">i" if size == 4 else ">h"
-        if not bigendian:
-            fmt = "<i" if size == 4 else "<h"
-        f.write(struct.pack(fmt, val))
+        f.write(pack_int(val, size, bigendian))
         size_written += size
     pad = 3600 - size_written
     if pad > 0:
@@ -64,13 +63,9 @@ def write_traceheader(
         Write numbers in big-endian order when ``True``.
     """
     buf = bytearray(240)
-    for key in TH_BYTE2SAMPLE:
+    for key, (offset, size) in TH_BYTE2SAMPLE.items():
         val = getattr(th, key)
-        offset, size = TH_BYTE2SAMPLE[key]
-        fmt = ">i" if size == 4 else ">h"
-        if not bigendian:
-            fmt = "<i" if size == 4 else "<h"
-        struct.pack_into(fmt, buf, offset, val)
+        struct.pack_into(struct_fmt(size, bigendian), buf, offset, val)
     f.write(buf)
 
 
@@ -88,17 +83,11 @@ def write_block(f: BinaryIO, block: SeisBlock, bigendian: bool = True) -> None:
         Write numbers in big-endian order when ``True``.
     """
     write_fileheader(f, block.fileheader, bigendian)
-    ns = block.fileheader.bfh.ns
     dsf = block.fileheader.bfh.DataSampleFormat
     for i, hdr in enumerate(block.traceheaders):
         trace = block.data[:, i]
         write_traceheader(f, hdr, bigendian)
-        if dsf == 1:
-            converted = b"".join(ieee_to_ibm(float(x)) for x in trace)
-            f.write(converted)
-        else:
-            fmt = ">%df" % ns if bigendian else "<%df" % ns
-            f.write(struct.pack(fmt, *trace))
+        write_samples(f, trace, dsf, bigendian)
 
 
 def segy_write(path: str, block: SeisBlock, fs=None) -> None:
@@ -115,8 +104,6 @@ def segy_write(path: str, block: SeisBlock, fs=None) -> None:
     """
     print(f"Writing SEGY file {path}")
 
-    opener = fs.open if fs is not None else open
-
-    with opener(path, "wb") as f:
+    with open_file(path, "wb", fs) as f:
         write_block(f, block)
     print(f"Finished writing {path}")


### PR DESCRIPTION
## Summary
- add memoized helpers for struct usage
- simplify integer pack/unpack with cached `struct.Struct`
- adjust docstrings across modules for consistent multi-line style
- update tests to follow docstring convention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861aa024850832fb198805973b29663